### PR TITLE
QAT-460

### DIFF
--- a/jest.config.integration.js
+++ b/jest.config.integration.js
@@ -3,7 +3,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFiles: [],
-  timers: 'fake',
   globals: {
     'ts-jest': {
         diagnostics: false

--- a/test/integration/src/client-helper.js
+++ b/test/integration/src/client-helper.js
@@ -1,4 +1,4 @@
-const configUtil = require('./config-helper');
+const configHelper = require('./config-helper');
 const revai = require('../../../dist/src/api-client');
 const JobStatus = require('../../../dist/src/models/JobStatus').JobStatus;
 const JobType = require('../../../dist/src/models/JobType').JobType;
@@ -6,7 +6,7 @@ const JobType = require('../../../dist/src/models/JobType').JobType;
 module.exports = {
     getClient: (apiKey) => {
         const client = new revai.RevAiApiClient(apiKey);
-        client.apiHandler.instance.defaults.baseURL = `https://${configUtil.getBaseUrl()}/revspeech/v1/`;
+        client.apiHandler.instance.defaults.baseURL = `https://${configHelper.getBaseUrl()}/revspeech/v1/`;
         return client;
     },
     getTranscribedJobId: (jobList) => {

--- a/test/integration/test/captions.test.js
+++ b/test/integration/test/captions.test.js
@@ -7,19 +7,18 @@ const InstanceStateError = require('../../../src/models/RevAiApiError').InvalidS
 beforeAll(async (done) => {
     const jobList = await client.getListOfJobs();
     var jobId;
-    if(jobList != undefined) {
+    if(jobList !== undefined) {
         jobId = clientHelper.getTranscribedJobId(jobList);
     }
-    if(jobId == undefined) {
+    if(jobId === undefined) {
         const job = await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
         jobId = job.id;
     }
-    var count = 0;
-    var intervalObject = setInterval(function(){ 
-        count++;
+
+    var intervalObject = setInterval(function() { 
         (async () => {
             const jobDetails = await client.getJobDetails(jobId);
-            if (jobDetails.status == JobStatus.Transcribed || count >= 40) { 
+            if (jobDetails.status == JobStatus.Transcribed) { 
                 clearInterval(intervalObject);
                 done();
             }

--- a/test/integration/test/list.test.js
+++ b/test/integration/test/list.test.js
@@ -5,10 +5,9 @@ const client = clientHelper.getClient(configHelper.getApiKey());
 
 beforeAll(async (done) => {
     const jobList = await client.getListOfJobs();
-    if(jobList == undefined || jobList.length < 2) {
-        for(var i = 0; i < 2; i++) {
-            await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
-        }
+    if(jobList === undefined || jobList.length < 2) {
+        await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
+        await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
     }
     done();
 }, 10000)

--- a/test/integration/test/list.test.js
+++ b/test/integration/test/list.test.js
@@ -1,17 +1,26 @@
 const clientHelper = require('../src/client-helper');
 const configHelper = require('../src/config-helper');
 const RevAiApiJob = require('../../../dist/src/models/RevAiApiJob')
+const client = clientHelper.getClient(configHelper.getApiKey());
+
+beforeAll(async (done) => {
+    const jobList = await client.getListOfJobs();
+    if(jobList == undefined || jobList.length < 2) {
+        for(var i = 0; i < 2; i++) {
+            await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
+        }
+    }
+    done();
+}, 10000)
 
 test('Can get list of jobs', async () => {
-    const client = clientHelper.getClient(configHelper.getApiKey());
     const jobList = await client.getListOfJobs();
     jobList.forEach((revAiJob) => {
         expect(revAiJob).toMatchObject(RevAiApiJob);
     })
-});
+})
 
 test('Can get single job', async () => {
-    const client = clientHelper.getClient(configHelper.getApiKey());
     const jobList = await client.getListOfJobs(1);
     expect(jobList.length).toEqual(1);
     expect(jobList[0]).toMatchObject(RevAiApiJob);

--- a/test/integration/test/transcript.test.js
+++ b/test/integration/test/transcript.test.js
@@ -1,8 +1,32 @@
 const clientHelper = require('../src/client-helper');
 const configHelper = require('../src/config-helper');
+const JobStatus = require('../../../dist/src/models/JobStatus').JobStatus;
+const client = clientHelper.getClient(configHelper.getApiKey());
+
+beforeAll(async (done) => {
+    const jobList = await client.getListOfJobs();
+    var jobId;
+    if(jobList != undefined) {
+        jobId = clientHelper.getTranscribedJobId(jobList);
+    }
+    if(jobId == undefined) {
+        const job = await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
+        jobId = job.id;
+    }
+    var count = 0;
+    var intervalObject = setInterval(function(){ 
+        count++;
+        (async () => {
+            const jobDetails = await client.getJobDetails(jobId);
+            if (jobDetails.status == JobStatus.Transcribed || count >= 40) { 
+                clearInterval(intervalObject);
+                done();
+            }
+        })()
+    }, 15000);
+}, 600000)
 
 test('Can get JSON transcript', async (done) => {
-    const client = clientHelper.getClient(configHelper.getApiKey());
     const jobList = await client.getListOfJobs();
     const jobId = clientHelper.getTranscribedJobId(jobList);
     expect(jobId).toBeDefined();
@@ -26,7 +50,6 @@ test('Can get JSON transcript', async (done) => {
 });
 
 test('JSON stream is equivalent to JSON object', async (done) => {
-    const client = clientHelper.getClient(configHelper.getApiKey());
     const jobList = await client.getListOfJobs();
     const jobId = clientHelper.getTranscribedJobId(jobList);
     expect(jobId).toBeDefined();
@@ -44,7 +67,6 @@ test('JSON stream is equivalent to JSON object', async (done) => {
 })
 
 test('Can get text transcript', async (done) => {
-    const client = clientHelper.getClient(configHelper.getApiKey());
     const jobList = await client.getListOfJobs();
     const jobId = clientHelper.getTranscribedJobId(jobList);
     expect(jobId).toBeDefined();
@@ -55,13 +77,11 @@ test('Can get text transcript', async (done) => {
 })
 
 test('Text stream is equivalent to text string', async (done) => {
-    const client = clientHelper.getClient(configHelper.getApiKey());
     const jobList = await client.getListOfJobs();
     const jobId = clientHelper.getTranscribedJobId(jobList);
     expect(jobId).toBeDefined();
     const textString = await client.getTranscriptText(jobId);
     const textStream = await client.getTranscriptTextStream(jobId);
-    //console.log('String: ' + textString);
     var streamString = '';
     textStream.on('data', data => {
         streamString += data.toString();

--- a/test/integration/test/transcript.test.js
+++ b/test/integration/test/transcript.test.js
@@ -6,19 +6,17 @@ const client = clientHelper.getClient(configHelper.getApiKey());
 beforeAll(async (done) => {
     const jobList = await client.getListOfJobs();
     var jobId;
-    if(jobList != undefined) {
+    if(jobList !== undefined) {
         jobId = clientHelper.getTranscribedJobId(jobList);
     }
-    if(jobId == undefined) {
+    if(jobId === undefined) {
         const job = await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
         jobId = job.id;
     }
-    var count = 0;
     var intervalObject = setInterval(function(){ 
-        count++;
         (async () => {
             const jobDetails = await client.getJobDetails(jobId);
-            if (jobDetails.status == JobStatus.Transcribed || count >= 40) { 
+            if (jobDetails.status == JobStatus.Transcribed) { 
                 clearInterval(intervalObject);
                 done();
             }


### PR DESCRIPTION
* Added beforeAll methods to tests that rely on having `transcribed` jobs available
* Removed the fake timer property from the integration tests to allow the use of setInterval polling

The beforeAll method has the potential to run for about 10 minutes. I noticed that jobs can take anywhere from 3 - 10+ minutes to complete so I opted for the higher value. If this is unreasonable let me know and we can adjust it.