### PR TITLE
AISDK-126: Fix stream with custom vocab integration test in Node SDK

### DIFF
--- a/test/integration/src/client-helper.js
+++ b/test/integration/src/client-helper.js
@@ -1,24 +1,30 @@
 const configHelper = require('./config-helper');
 const revaiAsync = require('../../../dist/src/api-client');
 const revaiCustomVocabularies = require('../../../dist/src/custom-vocabularies-client');
+const revaiStreaming = require('../../../dist/src/streaming-client');
 const JobStatus = require('../../../dist/src/models/JobStatus').JobStatus;
 const JobType = require('../../../dist/src/models/JobType').JobType;
 
 module.exports = {
-    getAsyncClient: (apiKey) => {
+    getAsyncClient: (apiKey = configHelper.getApiKey()) => {
         const client = new revaiAsync.RevAiApiClient(apiKey);
         client.apiHandler.instance.defaults.baseURL = `https://${configHelper.getBaseUrl()}/speechtotext/v1/`;
         return client;
     },
-    getCustomVocabulariesClient: (apiKey) => {
+    getStreamingClient: (audioConfig, apiKey = configHelper.getApiKey()) => {
+        const client = new revaiStreaming.RevAiStreamingClient(apiKey, audioConfig);
+        client.baseUrl = `wss://${configHelper.getBaseUrl()}/speechtotext/v1/stream`;
+        return client;
+    },
+    getCustomVocabulariesClient: (apiKey = configHelper.getApiKey()) => {
         const client = new revaiCustomVocabularies.RevAiCustomVocabulariesClient(apiKey);
         client.apiHandler.instance.defaults.baseURL = `https://${configHelper.getBaseUrl()}/speechtotext/v1/vocabularies`;
         return client;
     },
     getTranscribedJobId: (jobList) => {
         var completedJobId;
-        for(job of jobList) {
-            if(job.status === JobStatus.Transcribed && job.type != JobType.Stream) {
+        for (job of jobList) {
+            if (job.status === JobStatus.Transcribed && job.type !== JobType.Stream) {
                 completedJobId = job.id;
             }
         }

--- a/test/integration/test/account.test.js
+++ b/test/integration/test/account.test.js
@@ -14,9 +14,7 @@ test('Cannot authenticate with invalid token', async () => {
     try {
         await client.getAccount();
     } catch (error) {
-        var revAiError = error;
-    } finally {
-        expect(revAiError.statusCode).toEqual(401);
-        expect(revAiError.title).toBe('Authorization has been denied for this request.');
+        expect(error.statusCode).toEqual(401);
+        expect(error.title).toBe('Authorization has been denied for this request.');
     }
 }, 15000);

--- a/test/integration/test/account.test.js
+++ b/test/integration/test/account.test.js
@@ -2,7 +2,7 @@ const clientHelper = require('../src/client-helper');
 const configHelper = require('../src/config-helper');
 
 test('Can return email and balance', async () => {
-    const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+    const client = clientHelper.getAsyncClient();
     const account = await client.getAccount();
     expect(account.email).toBe(configHelper.getUserEmail());
     expect(account.balance_seconds).not.toBeNull();

--- a/test/integration/test/captions.test.js
+++ b/test/integration/test/captions.test.js
@@ -1,7 +1,6 @@
 const clientHelper = require('../src/client-helper');
-const configHelper = require('../src/config-helper');
 const JobStatus = require('../../../dist/src/models/JobStatus').JobStatus;
-const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+const client = clientHelper.getAsyncClient();
 const InvalidParameterError = require('../../../src/models/RevAiApiError').InvalidParameterError;
 
 beforeAll(async (done) => {

--- a/test/integration/test/custom_vocabularies.test.js
+++ b/test/integration/test/custom_vocabularies.test.js
@@ -1,7 +1,6 @@
 const clientHelper = require('../src/client-helper');
-const configHelper = require('../src/config-helper');
 const CustomVocabularyStatus = require('../../../dist/src/models/CustomVocabularyStatus').CustomVocabularyStatus;
-const client = clientHelper.getCustomVocabulariesClient(configHelper.getApiKey());
+const client = clientHelper.getCustomVocabulariesClient();
 
 test('Can submit custom vocabulary', async () => {
     const informationSubmit = await client.submitCustomVocabularies([{phrases:['some','custom','vocabularies']}]);

--- a/test/integration/test/job.test.js
+++ b/test/integration/test/job.test.js
@@ -27,7 +27,6 @@ test('Can submit buffer', async (done) => {
         const job = await client.submitJobAudioData(data, undefined, options);
         expect(job.status).toBe('in_progress');
         expect(job.id).not.toBeNull();
-        console.log(job.id);
         done();
     });
 }, 30000);

--- a/test/integration/test/job.test.js
+++ b/test/integration/test/job.test.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
 const clientHelper = require('../src/client-helper');
-const configHelper = require('../src/config-helper');
 
 test('Can submit local file', async () => {
-    const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+    const client = clientHelper.getAsyncClient();
     const options = new Object();
     options.metadata = 'Node sdk submit local file';
     const job = await client.submitJobLocalFile('./test/integration/resources/test_mp3.mp3', options);
@@ -12,7 +11,7 @@ test('Can submit local file', async () => {
 }, 30000);
 
 test('Can submit url', async () => {
-    const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+    const client = clientHelper.getAsyncClient();
     const options = new Object();
     options.metadata = 'Node sdk submit url';
     const job = await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3', options);
@@ -21,7 +20,7 @@ test('Can submit url', async () => {
 }, 30000);
 
 test('Can submit buffer', async (done) => {
-    const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+    const client = clientHelper.getAsyncClient();
     const options = new Object();
     options.metadata = 'Node sdk submit buffer';
     const fileStream = fs.readFile('./test/integration/resources/test_mp3.mp3', async (err, data) => {
@@ -34,7 +33,7 @@ test('Can submit buffer', async (done) => {
 }, 30000);
 
 test('Can submit buffer with filename', async (done) => {
-    const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+    const client = clientHelper.getAsyncClient();
     const options = new Object();
     options.metadata = 'Node sdk submit buffer';
     const fileStream = fs.readFile('./test/integration/resources/test_mp3.mp3', async (err, data) => {
@@ -46,7 +45,7 @@ test('Can submit buffer with filename', async (done) => {
 }, 30000);
 
 test('Can submit ReadableStream', async () => {
-    const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+    const client = clientHelper.getAsyncClient();
     const options = new Object();
     const fileStream = fs.createReadStream('./test/integration/resources/test_mp3.mp3');
     options.metadata = 'Node sdk submit ReadableStream';

--- a/test/integration/test/list.test.js
+++ b/test/integration/test/list.test.js
@@ -1,26 +1,25 @@
 const clientHelper = require('../src/client-helper');
-const configHelper = require('../src/config-helper');
 const RevAiApiJob = require('../../../dist/src/models/RevAiApiJob')
-const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+const client = clientHelper.getAsyncClient();
 
 beforeAll(async (done) => {
     const jobList = await client.getListOfJobs();
-    if(jobList === undefined || jobList.length < 2) {
+    if (jobList === undefined || jobList.length < 2) {
         await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
         await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3');
     }
     done();
-}, 60000)
+}, 60000);
 
 test('Can get list of jobs', async () => {
     const jobList = await client.getListOfJobs();
     jobList.forEach((revAiJob) => {
         expect(revAiJob).toMatchObject(RevAiApiJob);
-    })
-}, 30000)
+    });
+}, 30000);
 
 test('Can get single job', async () => {
     const jobList = await client.getListOfJobs(1);
     expect(jobList.length).toEqual(1);
     expect(jobList[0]).toMatchObject(RevAiApiJob);
-}, 30000)
+}, 30000);

--- a/test/integration/test/status.test.js
+++ b/test/integration/test/status.test.js
@@ -1,15 +1,12 @@
 const clientHelper = require('../src/client-helper');
-const configHelper = require('../src/config-helper');
 
 test('Job not found', async() => {
-    const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+    const client = clientHelper.getAsyncClient();
     const randomString = Math.random().toString(36).replace('0.', '');
     try {
         await client.getJobDetails(randomString);
     } catch (error) {
-        var revAiError = error;
-    } finally {
-        expect(revAiError.statusCode).toEqual(404);
-        expect(revAiError.title).toBe('could not find job');
+        expect(error.statusCode).toEqual(404);
+        expect(error.title).toBe('could not find job');
     }
 }, 30000);

--- a/test/integration/test/stream.js
+++ b/test/integration/test/stream.js
@@ -1,34 +1,42 @@
-const {AudioConfig} = require('../../../dist/src/models/streaming/AudioConfig');
-const {SessionConfig} = require('../../../dist/src/models/streaming/SessionConfig');
-const {CustomVocabularyStatus} = require('../../../dist/src/models/CustomVocabularyStatus');
-const {RevAiStreamingClient} = require('../../../dist/src/streaming-client');
-const {RevAiCustomVocabulariesClient} = require('../../../dist/src/custom-vocabularies-client')
-const configHelper = require('../src/config-helper');
+const { AudioConfig } = require('../../../dist/src/models/streaming/AudioConfig');
+const { SessionConfig } = require('../../../dist/src/models/streaming/SessionConfig');
+const { CustomVocabularyStatus } = require('../../../dist/src/models/CustomVocabularyStatus');
+const clientHelper = require('../src/client-helper');
+
 const fs = require('fs');
 const assert = require('assert');
 
+const audioConfig = new AudioConfig("audio/x-raw", 'interleaved', 16000, 'S16LE', 1);
+
+const handleHttpResponse = (code) => {
+    throw new Error(`Streaming client received http response with code: ${code}`);
+};
+
+const handleConnectFailed = (error) => {
+    throw new Error(`Connection failed with error: ${error}`);
+};
+
+const handleStreamError = (error) => {
+    throw new Error(`Streaming error occurred: ${error}`);
+};
+
 // Test Streaming Client
 (async () => {
-    const audioConfig = new AudioConfig("audio/x-raw", 'interleaved', 16000, 'S16LE', 1);
-    const client = new RevAiStreamingClient(configHelper.getApiKey(), audioConfig);
-    client.baseUrl = `wss://${configHelper.getBaseUrl()}/speechtotext/v1/stream`;
+    const client = clientHelper.getStreamingClient(audioConfig);
 
     client.on('close', (code, reason) => {
         assertCloseCodeAndReason(code, reason);
-        printPassStatement();
+        printPassStatement("Streaming");
         return;
     });
-    client.on('httpResponse', code => {
-        throw new Error(`Streaming client received http response with code: ${code}`);
-    });
-    client.on('connectFailed', error => {
-        throw new Error(`Connection failed with error: ${error}`);
-    });
+
+    client.on('httpResponse', handleHttpResponse);
+    client.on('connectFailed', handleConnectFailed);
     client.on('connect', connectionMessage => {
         console.log(`Connected with job id: ${connectionMessage.id}`);
     });
 
-    var stream = client.start();
+    const stream = client.start();
 
     stream.on('data', data => {
         if (data.type === 'partial') {
@@ -40,67 +48,42 @@ const assert = require('assert');
         }
     });
 
-    stream.on('error', (error) => {
-        throw new Error(`Streaming error occurred: ${error}`);
-    });
+    stream.on('error', handleStreamError);
 
-    var file = fs.createReadStream('./test/integration/resources/english_test.raw');
-
-    file.on('end', () => {
-        client.end();
-    });
-
-    file.once('readable', () => {
-        file.pipe(stream);
-    });
+    const file = fs.createReadStream('./test/integration/resources/english_test.raw');
+    file.on('end', () => client.end());
+    file.once('readable', () => file.pipe(stream));
 })();
 
-
-// Test Streaming Client with Custom Vocabs Passed
+// Test Streaming Client with Custom Vocabulary
 (async () => {
-    const audioConfig = new AudioConfig("audio/x-raw", 'interleaved', 16000, 'S16LE', 1);
-    const client = new RevAiStreamingClient(configHelper.getApiKey(), audioConfig);
-    client.baseUrl = `wss://${configHelper.getBaseUrl()}/speechtotext/v1/stream`;
+    const cvClient = clientHelper.getCustomVocabulariesClient();
+    let cvSubmission = await cvClient.submitCustomVocabularies([{ phrases: [ "test", "vocabularies" ] }]);
+    const stillInProgress = async () => {
+        cvSubmission = await cvClient.getCustomVocabularyInformation(cvSubmission.id);
+        return cvSubmission.status === CustomVocabularyStatus.InProgress;
+    };
 
-    client.on('close', (code, reason) => {
-        assertCloseCodeAndReason(code, reason);
-        printPassStatement('Stream with Custom Vocabulary');
-        return;
-    });
-    client.on('httpResponse', code => {
-        throw new Error(`Streaming client received http response with code: ${code}`);
-    });
-    client.on('connectFailed', error => {
-        throw new Error(`Connection failed with error: ${error}`);
-    });
-
-    const cv_client = new RevAiCustomVocabulariesClient(configHelper.getApiKey());
-
-    var cv_submission = await cv_client.submitCustomVocabularies([{
-            phrases: [
-                "test",
-                "vocabularies"
-            ]
-        }]);
-
-    while(
-        (cv_submission = await cv_client.getCustomVocabularyInformation(cv_submission.id)).status
-            == CustomVocabularyStatus.InProgress
-    )
-    {
+    while (await stillInProgress()) {
         await new Promise(resolve => setTimeout(resolve, 5000));
     }
 
-    console.log('Custom Vocabulary Processed with status: ', cv_submission.status);
-    assertCustomVocabulariesCompleted(cv_submission.status);
+    assertCustomVocabulariesCompleted(cvSubmission.status);
 
-    const sessionConfig = new SessionConfig(customVocabularyID=cv_submission.id);
+    const client = clientHelper.getStreamingClient(audioConfig);
 
+    client.on('close', (code, reason) => {
+        assertCloseCodeAndReason(code, reason);
+        printPassStatement('Streaming with Custom Vocabulary');
+    });
+    client.on('httpResponse', handleHttpResponse);
+    client.on('connectFailed', handleConnectFailed);
     client.on('connect', connectionMessage => {
-        console.log(`Connected with job id: ${connectionMessage.id} and CustomVocabulary id: ${cv_submission.id}`);
+        console.log(`Connected with job ID: ${connectionMessage.id} and custom vocabulary ID: ${cvSubmission.id}`);
     });
 
-    var stream = client.start(sessionConfig);
+    const sessionConfig = new SessionConfig(customVocabularyID=cvSubmission.id);
+    const stream = client.start(sessionConfig);
 
     stream.on('data', data => {
         if (data.type === 'partial') {
@@ -112,29 +95,21 @@ const assert = require('assert');
         }
     });
 
-    stream.on('error', (error) => {
-        throw new Error(`Streaming error occurred: ${error}`);
-    });
+    stream.on('error', handleStreamError);
 
-    var file = fs.createReadStream('./test/integration/resources/english_test.raw');
-
-    file.on('end', () => {
-        client.end();
-    });
-
-    file.once('readable', () => {
-        file.pipe(stream);
-    });
+    const file = fs.createReadStream('./test/integration/resources/english_test.raw');
+    file.on('end', () => client.end());
+    file.once('readable', () => file.pipe(stream));
 })();
 
-function assertPartialHypothesis(partial) {
+const assertPartialHypothesis = (partial) => {
     partial.elements.forEach(element => {
         assert.equal(element.type, 'text', 'Expected element type to be [text]: ' + JSON.stringify(element));
         assert.notEqual(element.value, 'undefined', 'Expected element value to not be [undefined]: ' + JSON.stringify(element));
     });
 }
 
-function assertFinalHypothesis(final) {
+const assertFinalHypothesis = (final) => {
     assert.ok(final.ts < final.end_ts);
     final.elements.forEach(element => {
         if (element.type === 'punct') {
@@ -148,15 +123,16 @@ function assertFinalHypothesis(final) {
     });
 }
 
-function assertCloseCodeAndReason(code, reason) {
-    assert.equal(code, 1000, `Expected close code to be [1000] but was ${code}`);
-    assert.equal(reason, 'End of input. Closing', `Expected close reason to be [End of input. Closing] but was ${reason}`);
+const assertCloseCodeAndReason = (code, reason) => {
+    assert.equal(code, 1000, `Expected close code to be [1000] but was [${code}]`);
+    assert.equal(reason, 'End of input. Closing', `Expected close reason to be [End of input. Closing] but was [${reason}]`);
 }
 
-function assertCustomVocabulariesCompleted(status) {
+const assertCustomVocabulariesCompleted = (status) => {
     assert.equal(status, CustomVocabularyStatus.Complete);
 }
 
-function printPassStatement(testName='') {
-    console.log(`PASS Integration ${testName} test/integration/test/stream.js`);
+const printPassStatement = (name='') => {
+    const test = name ? `[${name}] ` : '';
+    console.log(`PASS Integration ${test}test/integration/test/stream.js`);
 }

--- a/test/integration/test/stream.js
+++ b/test/integration/test/stream.js
@@ -33,7 +33,7 @@ const handleStreamError = (error) => {
     client.on('httpResponse', handleHttpResponse);
     client.on('connectFailed', handleConnectFailed);
     client.on('connect', connectionMessage => {
-        console.log(`Connected with job id: ${connectionMessage.id}`);
+        console.log(`Connected with job ID: ${connectionMessage.id}`);
     });
 
     const stream = client.start();

--- a/test/integration/test/transcript.test.js
+++ b/test/integration/test/transcript.test.js
@@ -1,7 +1,7 @@
 const clientHelper = require('../src/client-helper');
 const configHelper = require('../src/config-helper');
 const JobStatus = require('../../../dist/src/models/JobStatus').JobStatus;
-const client = clientHelper.getAsyncClient(configHelper.getApiKey());
+const client = clientHelper.getAsyncClient();
 
 beforeAll(async (done) => {
     const jobList = await client.getListOfJobs();


### PR DESCRIPTION
Changes
- Fixed the integration test to use `client-helper.getCustomVocabulariesClient` instead of the default constructor
- Refactor some of the testing code in `stream.js`
- Added a `getStreamingClient` to `client-helper`
- Added default parameter of API key to the client helpers to simplify testing