### PR TITLE
AISDK-204 Node sdk linting fails on long docs links

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -53,7 +53,10 @@
       ],
       "max-line-length": [
         true,
-        120
+        {
+          "limit": 120,
+          "ignore-pattern": "https://docs.rev.ai"
+        }
       ],
       "no-require-imports": false,
       "no-trailing-whitespace": true,


### PR DESCRIPTION
This should ignore the line limit on any lines with a link to the docs. Needed because some links are longer than the column limit, e.g. "https://docs.rev.ai/api/custom-vocabulary/reference/#operation/SubmitCustomVocabulary!path=custom_vocabularies&t=request"