### PR TITLE
AISDK-221: Fix HIPAA Error Message on Incorrect Usage

### DIFF
--- a/src/api-request-handler.ts
+++ b/src/api-request-handler.ts
@@ -63,14 +63,10 @@ export class ApiRequestHandler {
             switch (error.response.status) {
                 case 400:
                     throw new InvalidParameterError(error);
-                case 401:
-                case 403:
-                case 404:
-                    throw new RevAiApiError(error);
                 case 409:
                     throw new InvalidStateError(error);
                 default:
-                    throw error;
+                    throw new RevAiApiError(error);
             }
         }
     }

--- a/src/api-request-handler.ts
+++ b/src/api-request-handler.ts
@@ -68,7 +68,11 @@ export class ApiRequestHandler {
                 case 404:
                     throw new RevAiApiError(error);
                 case 403:
-                    throw new InsufficientCreditsError(error);
+                    if (error.response.data.error.includes("Not enough credits for payment")) {
+                        throw new InsufficientCreditsError(error);
+                    } else {
+                        throw new RevAiApiError(error)
+                    }
                 case 409:
                     throw new InvalidStateError(error);
                 default:

--- a/src/api-request-handler.ts
+++ b/src/api-request-handler.ts
@@ -65,14 +65,9 @@ export class ApiRequestHandler {
                 case 400:
                     throw new InvalidParameterError(error);
                 case 401:
+                case 403:
                 case 404:
                     throw new RevAiApiError(error);
-                case 403:
-                    if (error.response.data.error.includes("Not enough credits for payment")) {
-                        throw new InsufficientCreditsError(error);
-                    } else {
-                        throw new RevAiApiError(error)
-                    }
                 case 409:
                     throw new InvalidStateError(error);
                 default:

--- a/src/api-request-handler.ts
+++ b/src/api-request-handler.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 
 import {
-    InsufficientCreditsError,
     InvalidParameterError,
     InvalidStateError,
     RevAiApiError

--- a/src/models/RevAiApiError.ts
+++ b/src/models/RevAiApiError.ts
@@ -3,14 +3,14 @@ import { AxiosError } from 'axios';
 export class RevAiApiError {
     statusCode: number;
     title: string;
-    detail?: string;
+    error?: string;
     type?: string;
 
     constructor(e: AxiosError) {
         if (e.response) {
             this.statusCode = e.response.status;
             this.title = e.response.data.title || '';
-            this.detail = e.response.data.detail || '';
+            this.error = e.response.data.error || '';
             this.type = e.response.data.type || '';
         }
     }

--- a/src/models/RevAiApiError.ts
+++ b/src/models/RevAiApiError.ts
@@ -2,16 +2,12 @@ import { AxiosError } from 'axios';
 
 export class RevAiApiError {
     statusCode: number;
-    title: string;
-    error?: string;
-    type?: string;
+    details: string;
 
     constructor(e: AxiosError) {
         if (e.response) {
             this.statusCode = e.response.status;
-            this.title = e.response.data.title || '';
-            this.error = e.response.data.error || '';
-            this.type = e.response.data.type || '';
+            this.details = e.response.data || '';
         }
     }
 }

--- a/src/models/RevAiApiError.ts
+++ b/src/models/RevAiApiError.ts
@@ -35,12 +35,3 @@ export class InvalidStateError extends RevAiApiError {
         this.allowedValues = e.response.data.allowed_values;
     }
 }
-
-export class InsufficientCreditsError extends RevAiApiError {
-    currentBalance: number;
-
-    constructor(e: AxiosError) {
-        super(e);
-        this.currentBalance = e.response.data.current_balance;
-    }
-}

--- a/test/unit/api-request-handler.spec.ts
+++ b/test/unit/api-request-handler.spec.ts
@@ -3,7 +3,6 @@ import { Readable, Transform, Writable } from 'stream';
 
 import { ApiRequestHandler, AxiosResponseTypes, HttpMethodTypes } from '../../src/api-request-handler';
 import {
-    InsufficientCreditsError,
     InvalidParameterError,
     InvalidStateError,
     RevAiApiError
@@ -12,7 +11,6 @@ import {
 import {
     objectToStream,
     setupFakeApiError,
-    setupFakeInsufficientCreditsError,
     setupFakeInvalidParametersError,
     setupFakeInvalidStateError
 } from './testhelpers';
@@ -174,29 +172,6 @@ describe('api-request-handler', () => {
                 await sut.makeApiRequest(method, endpoint, headers, responseType);
             } catch (e) {
                 expect(e).toEqual(new InvalidStateError(fakeError));
-            }
-            expect(axios.request).toBeCalledTimes(1);
-            expect(axios.request).toBeCalledWith({
-                method: method,
-                url: endpoint,
-                data: undefined,
-                headers: headers,
-                responseType: responseType
-            });
-        });
-
-        it('handles when api returns insufficient credits', async () => {
-            const method = 'get';
-            const endpoint = '/test';
-            const headers = { 'Header1' : 'test' };
-            const responseType = 'text';
-            const fakeError = setupFakeInsufficientCreditsError();
-            axios.request.mockImplementationOnce(() => Promise.reject(fakeError));
-
-            try {
-                await sut.makeApiRequest(method, endpoint, headers, responseType);
-            } catch (e) {
-                expect(e).toEqual(new InsufficientCreditsError(fakeError));
             }
             expect(axios.request).toBeCalledTimes(1);
             expect(axios.request).toBeCalledWith({

--- a/test/unit/testhelpers.ts
+++ b/test/unit/testhelpers.ts
@@ -51,16 +51,6 @@ export const setupFakeInvalidStateError = (): AxiosError => {
     return err;
 };
 
-export const setupFakeInsufficientCreditsError = (): AxiosError => {
-    let err = setupFakeApiError(403,
-        'You do not have enough credits',
-        'https://www.rev.ai/api/v1/errors/out-of-credit',
-        'You only have 60 seconds remaining'
-    );
-    err.response.data.current_balance = 60;
-    return err;
-};
-
 export const setupFakeInvalidParametersError = (): AxiosError => {
     let err = setupFakeApiError(400,
         "Your request parameters didn't validate",


### PR DESCRIPTION
Submission to the API with insufficient balance does not actually trigger a 403. The job submits successfully then fails. I also changed the error field as it looks like that wasn't ever populating. Now using the wrong parameter as HIPAA will return the right error. 