### PR TITLE
Adding support for enable_speaker_switch in streaming-client

### DIFF
--- a/examples/streaming_transcribe_from_local_file.js
+++ b/examples/streaming_transcribe_from_local_file.js
@@ -38,7 +38,8 @@ const sessionConfig = new revai.SessionConfig(
     transcriber='machine',    /* (optional) transcriber */
     detailedPartials=false,   /* (optional) detailed_partials */
     language='en',            /* (optional) language */
-    skipPostprocessing=false  /* (optional) skip_postprocessing */
+    skipPostprocessing=false, /* (optional) skip_postprocessing */
+    enableSpeakerSwitch=false /* (optional) enable_speaker_switch */
 );
 
 // Begin streaming session

--- a/src/models/streaming/SessionConfig.ts
+++ b/src/models/streaming/SessionConfig.ts
@@ -13,6 +13,7 @@ export class SessionConfig {
     detailedPartials?: boolean;
     language: string;
     skipPostprocessing?: boolean;
+    enableSpeakerSwitch?: boolean;
 
     /**
      * @param metadata (Optional) metadata to be associated with the streaming job
@@ -30,7 +31,8 @@ export class SessionConfig {
      * @param detailedPartials (Optional) whether to return detailed partials
      * @param language (Optional) language to use for the streaming job
      * @param skipPostprocessing (Optional) skip all text postprocessing
-     */
+     * @param enableSpeakerSwitch (Optional) whether to enable speaker switch detection
+    */
     constructor(
         metadata?: string,
         customVocabularyID?: string,
@@ -41,7 +43,8 @@ export class SessionConfig {
         transcriber?: string,
         detailedPartials?: boolean,
         language?: string,
-        skipPostprocessing?: boolean
+        skipPostprocessing?: boolean,
+        enableSpeakerSwitch?: boolean
     ) {
         this.metadata = metadata;
         this.customVocabularyID = customVocabularyID;
@@ -53,5 +56,6 @@ export class SessionConfig {
         this.detailedPartials = detailedPartials;
         this.language = language;
         this.skipPostprocessing = skipPostprocessing;
+        this.enableSpeakerSwitch = enableSpeakerSwitch;
     }
 }

--- a/src/models/streaming/StreamingResponses.ts
+++ b/src/models/streaming/StreamingResponses.ts
@@ -13,6 +13,7 @@ export interface StreamingResponse {
 export interface StreamingHypothesis extends StreamingResponse {
     ts?: number;
     end_ts?: number;
+    speaker_id?: number;
     elements: Element[];
 }
 

--- a/src/streaming-client.ts
+++ b/src/streaming-client.ts
@@ -137,6 +137,9 @@ export class RevAiStreamingClient extends EventEmitter {
             if (config.skipPostprocessing) {
                 url += '&skip_postprocessing=true';
             }
+            if (config.enableSpeakerSwitch) {
+                url += '&enable_speaker_switch=true';
+            }
         }
 
         this.client.connect(url);

--- a/test/unit/streaming-client.spec.ts
+++ b/test/unit/streaming-client.spec.ts
@@ -36,7 +36,9 @@ describe('streaming-client', () => {
                 10,
                 'machine',
                 true,
-                'en'
+                'en',
+                true,
+                true
             );
 
             // Act
@@ -55,7 +57,9 @@ describe('streaming-client', () => {
                 `&detailed_partials=${encodeURIComponent(config.detailedPartials)}` +
                 `&start_ts=${encodeURIComponent(config.startTs)}` +
                 `&transcriber=${encodeURIComponent(config.transcriber)}` +
-                `&language=${encodeURIComponent(config.language)}`
+                `&language=${encodeURIComponent(config.language)}` +
+                `&skip_postprocessing=${encodeURIComponent(config.skipPostprocessing)}` +
+                `&enable_speaker_switch=${encodeURIComponent(config.enableSpeakerSwitch)}`
             );
             expect(mockClient.connect).toBeCalledTimes(1);
             expect(res.writable).toBe(true);


### PR DESCRIPTION
Adding "enable_speaker_switch" on Session Config.
Additionally, adding speaker_id in the StreamingHypothesis type so that hypothesis users can grab the corresponding id out.

Unit tests, lint, and build succeed locally. Tested by copying dist and successfully received hypothesis with speaker id  in local testing:

` {"type":"final","ts":3.91,"end_ts":7.71,"elements":[{"type":"text","value":"Think","ts":4.44,"end_ts":5,"confidence":0.29},{"type":"punct","value":" "},{"type":"text","value":"very","ts":5.63,"end_ts":6.12,"confidence":0.89},{"type":"punct","value":" "},{"type":"text","value":"testing","ts":6.12,"end_ts":6.44,"confidence":0.22},{"type":"punct","value":","},{"type":"punct","value":" "},{"type":"text","value":"testing","ts":6.44,"end_ts":7.08,"confidence":0.76},{"type":"punct","value":"."}],"speaker_id":"1001"}`