### PR TITLE
AISDK-232: Properly handle errors with undefined response property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revai-node-sdk",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Rev AI makes speech applications easy to build!",
   "main": "src/index.js",
   "scripts": {

--- a/src/api-request-handler.ts
+++ b/src/api-request-handler.ts
@@ -56,7 +56,7 @@ export class ApiRequestHandler {
 
             return response.data;
         } catch (error) {
-            if (error.response == null) {
+            if (error.response === null || error.response === undefined) {
                 throw error;
             }
             if (responseType === 'stream') {

--- a/src/api-request-handler.ts
+++ b/src/api-request-handler.ts
@@ -56,7 +56,7 @@ export class ApiRequestHandler {
 
             return response.data;
         } catch (error) {
-            if (error.response === null) {
+            if (error.response == null) {
                 throw error;
             }
             if (responseType === 'stream') {

--- a/test/unit/api-request-handler.spec.ts
+++ b/test/unit/api-request-handler.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Readable, Transform, Writable } from 'stream';
+import { Transform } from 'stream';
 import axios from 'axios';
 
-import { ApiRequestHandler, AxiosResponseTypes, HttpMethodTypes } from '../../src/api-request-handler';
+import { ApiRequestHandler } from '../../src/api-request-handler';
 import {
     InvalidParameterError,
     ForbiddenAccessError,
@@ -18,7 +18,7 @@ import {
     setupFakeForbiddenAccessError,
     setupFakeResourceNotFoundError,
     setupFakeUnsupportedApiError,
-    setupFakeInvalidStateError, fakeAxiosError
+    setupFakeInvalidStateError
 } from './testhelpers';
 
 describe('api-request-handler', () => {

--- a/test/unit/api-request-handler.spec.ts
+++ b/test/unit/api-request-handler.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Readable, Transform, Writable } from 'stream';
-import axios, {AxiosError} from 'axios';
+import axios from 'axios';
 
 import { ApiRequestHandler, AxiosResponseTypes, HttpMethodTypes } from '../../src/api-request-handler';
 import {


### PR DESCRIPTION
Throwing errors while you try to handle errors is no fun