### PR TITLE
REVAI-3917: Split NlpModel to have separate enums for Translation and Summarization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revai-node-sdk",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Rev AI makes speech applications easy to build!",
   "main": "src/index.js",
   "scripts": {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -318,12 +318,8 @@ export class RevAiApiClient {
      */
     async getTranslatedCaptions(id: string,
         language: string,
-        contentType?: string,
-        channelId?: number): Promise<Readable> {
+        contentType?: string): Promise<Readable> {
         let url = `/jobs/${id}/captions/translation/${language}`;
-        if (channelId) {
-            url += `?speaker_channel=${channelId}`;
-        }
         return await this.apiHandler.makeApiRequest<Readable>(
             'get', url, { 'Accept': contentType || CaptionType.SRT }, 'stream');
     }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -319,7 +319,7 @@ export class RevAiApiClient {
     async getTranslatedCaptions(id: string,
         language: string,
         contentType?: string): Promise<Readable> {
-        let url = `/jobs/${id}/captions/translation/${language}`;
+        const url = `/jobs/${id}/captions/translation/${language}`;
         return await this.apiHandler.makeApiRequest<Readable>(
             'get', url, { 'Accept': contentType || CaptionType.SRT }, 'stream');
     }

--- a/src/models/async/NlpModel.ts
+++ b/src/models/async/NlpModel.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow */
-/** Supported model types for NLP tasks like summarization. */
+/** Supported model types for summarization. */
 export enum NlpModel {
     STANDARD = 'standard',
     PREMIUM = 'premium'

--- a/src/models/async/SummarizationModel.ts
+++ b/src/models/async/SummarizationModel.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 /** Supported model types for summarization. */
-export enum NlpModel {
+export enum SummarizationModel {
     STANDARD = 'standard',
     PREMIUM = 'premium'
 }

--- a/src/models/async/SummarizationOptions.ts
+++ b/src/models/async/SummarizationOptions.ts
@@ -1,4 +1,4 @@
-import { NlpModel } from '../NlpModel';
+import { NlpModel } from './NlpModel';
 import { SummarizationFormattingOptions } from './SummarizationFormattingOptions';
 
 export interface SummarizationOptions {

--- a/src/models/async/SummarizationOptions.ts
+++ b/src/models/async/SummarizationOptions.ts
@@ -1,8 +1,8 @@
-import { NlpModel } from './NlpModel';
+import { SummarizationModel } from './SummarizationModel';
 import { SummarizationFormattingOptions } from './SummarizationFormattingOptions';
 
 export interface SummarizationOptions {
     prompt?: string;
-    model?: NlpModel;
+    model?: SummarizationModel;
     type?: SummarizationFormattingOptions;
 }

--- a/src/models/async/TranslationLanguageOptions.ts
+++ b/src/models/async/TranslationLanguageOptions.ts
@@ -1,6 +1,6 @@
-import { NlpModel } from '../NlpModel';
+import { TranslationMode } from './TranslationMode';
 
 export interface TranslationLanguageOptions {
     language: string;
-    model?: NlpModel;
+    model?: TranslationMode;
 }

--- a/src/models/async/TranslationLanguageOptions.ts
+++ b/src/models/async/TranslationLanguageOptions.ts
@@ -1,6 +1,6 @@
-import { TranslationMode } from './TranslationMode';
+import { TranslationModel} from './TranslationModel';
 
 export interface TranslationLanguageOptions {
     language: string;
-    model?: TranslationMode;
+    model?: TranslationModel;
 }

--- a/src/models/async/TranslationLanguageOptions.ts
+++ b/src/models/async/TranslationLanguageOptions.ts
@@ -1,4 +1,4 @@
-import { TranslationModel} from './TranslationModel';
+import { TranslationModel } from './TranslationModel';
 
 export interface TranslationLanguageOptions {
     language: string;

--- a/src/models/async/TranslationMode.ts
+++ b/src/models/async/TranslationMode.ts
@@ -1,0 +1,6 @@
+/* eslint-disable no-shadow */
+/** Supported model types for translation. */
+export enum TranslationMode {
+    STANDARD = 'standard',
+    PREMIUM = 'premium'
+}

--- a/src/models/async/TranslationModel.ts
+++ b/src/models/async/TranslationModel.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 /** Supported model types for translation. */
-export enum TranslationMode {
+export enum TranslationModel {
     STANDARD = 'standard',
     PREMIUM = 'premium'
 }

--- a/test/integration/test/async-translation-summarization.test.js
+++ b/test/integration/test/async-translation-summarization.test.js
@@ -4,7 +4,7 @@ const { SummarizationJobStatus } = require('../../../dist/src/models/async/Summa
 const { SummarizationFormattingOptions } = require('../../../dist/src/models/async/SummarizationFormattingOptions');
 const { TranslationJobStatus } = require('../../../dist/src/models/async/TranslationJobStatus');
 const { JobStatus } = require('../../../dist/src/models/JobStatus');
-const { NlpModel } = require('../../../dist/src/models/async/NlpModel');
+const { SummarizationModel } = require('../../../dist/src/models/async/SummarizationModel');
 const { TranslationModel } = require('../../../dist/src/models/async/TranslationModel');
 
 test('async translation/summarization submit local file', async () => {
@@ -16,7 +16,7 @@ test('async translation/summarization submit local file', async () => {
 
     options.summarization_config = {
         type:SummarizationFormattingOptions.Bullets,
-        model:NlpModel.PREMIUM,
+        model:SummarizationModel.PREMIUM,
         prompt:'Try to summarize this transcript as good as you possibly can'
     };
 
@@ -37,7 +37,7 @@ test('async translation/summarization submit local file', async () => {
     expect(job.id).not.toBeNull();
 
     expect(job.summarization).not.toBeNull();
-    expect(job.summarization.model).toBe(NlpModel.PREMIUM);
+    expect(job.summarization.model).toBe(SummarizationModel.PREMIUM);
     expect(job.summarization.type).toBe(SummarizationFormattingOptions.Bullets);
     expect(job.summarization.prompt).toBe('Try to summarize this transcript as good as you possibly can');
 
@@ -102,7 +102,7 @@ test('async translation/summarization submit url', async () => {
 
     options.summarization_config = {
         type:SummarizationFormattingOptions.Bullets,
-        model:NlpModel.PREMIUM,
+        model:SummarizationModel.PREMIUM,
         prompt: 'Try to summarize this transcript as good as you possibly can'
     };
 
@@ -123,7 +123,7 @@ test('async translation/summarization submit url', async () => {
     expect(job.id).not.toBeNull();
 
     expect(job.summarization).not.toBeNull();
-    expect(job.summarization.model).toBe(NlpModel.PREMIUM);
+    expect(job.summarization.model).toBe(SummarizationModel.PREMIUM);
     expect(job.summarization.type).toBe(SummarizationFormattingOptions.Bullets);
     expect(job.summarization.prompt).toBe('Try to summarize this transcript as good as you possibly can');
 

--- a/test/integration/test/async-translation-summarization.test.js
+++ b/test/integration/test/async-translation-summarization.test.js
@@ -5,7 +5,7 @@ const { SummarizationFormattingOptions } = require('../../../dist/src/models/asy
 const { TranslationJobStatus } = require('../../../dist/src/models/async/TranslationJobStatus');
 const { JobStatus } = require('../../../dist/src/models/JobStatus');
 const { NlpModel } = require('../../../dist/src/models/async/NlpModel');
-const { TranslationMode } = require('../../../dist/src/models/async/TranslationMode');
+const { TranslationModel } = require('../../../dist/src/models/async/TranslationModel');
 
 test('async translation/summarization submit local file', async () => {
     const client = clientHelper.getAsyncClient();
@@ -24,7 +24,7 @@ test('async translation/summarization submit local file', async () => {
         target_languages : [
         {
             language:'es',
-            model:TranslationMode.PREMIUM
+            model:TranslationModel.PREMIUM
         },
         {
             language:'ru'
@@ -61,7 +61,7 @@ test('async translation/summarization submit local file', async () => {
     expect(job.translation.completed_on).not.toBeNull();
     expect(job.translation.target_languages[0].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[0].language).toBe("es");
-    expect(job.translation.target_languages[0].model).toBe(TranslationMode.PREMIUM);
+    expect(job.translation.target_languages[0].model).toBe(TranslationModel.PREMIUM);
 
     expect(job.translation.target_languages[1].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[1].language).toBe("ru");
@@ -110,7 +110,7 @@ test('async translation/summarization submit url', async () => {
         target_languages : [
         {
             language:'es',
-            model:TranslationMode.PREMIUM
+            model:TranslationModel.PREMIUM
         },
         {
             language:'ru'
@@ -147,7 +147,7 @@ test('async translation/summarization submit url', async () => {
     expect(job.translation.completed_on).not.toBeNull();
     expect(job.translation.target_languages[0].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[0].language).toBe("es");
-    expect(job.translation.target_languages[0].model).toBe(TranslationMode.PREMIUM);
+    expect(job.translation.target_languages[0].model).toBe(TranslationModel.PREMIUM);
 
     expect(job.translation.target_languages[1].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[1].language).toBe("ru");

--- a/test/integration/test/async-translation-summarization.test.js
+++ b/test/integration/test/async-translation-summarization.test.js
@@ -4,7 +4,8 @@ const { SummarizationJobStatus } = require('../../../dist/src/models/async/Summa
 const { SummarizationFormattingOptions } = require('../../../dist/src/models/async/SummarizationFormattingOptions');
 const { TranslationJobStatus } = require('../../../dist/src/models/async/TranslationJobStatus');
 const { JobStatus } = require('../../../dist/src/models/JobStatus');
-const { NlpModel } = require('../../../dist/src/models/NlpModel');
+const { NlpModel } = require('../../../dist/src/models/async/NlpModel');
+const { TranslationMode } = require('../../../dist/src/models/async/TranslationMode');
 
 test('async translation/summarization submit local file', async () => {
     const client = clientHelper.getAsyncClient();
@@ -23,7 +24,7 @@ test('async translation/summarization submit local file', async () => {
         target_languages : [
         {
             language:'es',
-            model:NlpModel.PREMIUM
+            model:TranslationMode.PREMIUM
         },
         {
             language:'ru'
@@ -60,7 +61,7 @@ test('async translation/summarization submit local file', async () => {
     expect(job.translation.completed_on).not.toBeNull();
     expect(job.translation.target_languages[0].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[0].language).toBe("es");
-    expect(job.translation.target_languages[0].model).toBe(NlpModel.PREMIUM);
+    expect(job.translation.target_languages[0].model).toBe(TranslationMode.PREMIUM);
 
     expect(job.translation.target_languages[1].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[1].language).toBe("ru");
@@ -109,7 +110,7 @@ test('async translation/summarization submit url', async () => {
         target_languages : [
         {
             language:'es',
-            model:NlpModel.PREMIUM
+            model:TranslationMode.PREMIUM
         },
         {
             language:'ru'
@@ -146,7 +147,7 @@ test('async translation/summarization submit url', async () => {
     expect(job.translation.completed_on).not.toBeNull();
     expect(job.translation.target_languages[0].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[0].language).toBe("es");
-    expect(job.translation.target_languages[0].model).toBe(NlpModel.PREMIUM);
+    expect(job.translation.target_languages[0].model).toBe(TranslationMode.PREMIUM);
 
     expect(job.translation.target_languages[1].status).toBe(TranslationJobStatus.Completed);
     expect(job.translation.target_languages[1].language).toBe("ru");

--- a/test/integration/test/async-translation-summarization.test.js
+++ b/test/integration/test/async-translation-summarization.test.js
@@ -79,7 +79,7 @@ test('async translation/summarization submit local file', async () => {
     expect(translationObject1).not.toBeNull();
     var translationObject1Stream = client.getTranslatedTranscriptObjectStream(job.id,"es");
     expect(translationObject1Stream).not.toBeNull();
-    var translatedCaptionsStream1 = client.getTranslatedCaptions(job.id,"es", undefined, 0);
+    var translatedCaptionsStream1 = client.getTranslatedCaptions(job.id,"es", undefined);
     expect(translatedCaptionsStream1).not.toBeNull();
 
     var translationString2 = client.getTranslatedTranscriptText(job.id,"ru");
@@ -88,7 +88,7 @@ test('async translation/summarization submit local file', async () => {
     expect(translationObject2).not.toBeNull();
     var translationObject2Stream = client.getTranslatedTranscriptObjectStream(job.id,"ru");
     expect(translationObject2Stream).not.toBeNull();
-    var translatedCaptionsStream2 = client.getTranslatedCaptions(job.id,"ru", undefined, 0);
+    var translatedCaptionsStream2 = client.getTranslatedCaptions(job.id,"ru", undefined);
     expect(translatedCaptionsStream2).not.toBeNull();
 
 }, 180000);
@@ -165,7 +165,7 @@ test('async translation/summarization submit url', async () => {
     expect(translationObject1).not.toBeNull();
     var translationObject1Stream = client.getTranslatedTranscriptObjectStream(job.id,"es");
     expect(translationObject1Stream).not.toBeNull();
-    var translatedCaptionsStream1 = client.getTranslatedCaptions(job.id,"es", undefined, 0);
+    var translatedCaptionsStream1 = client.getTranslatedCaptions(job.id,"es", undefined);
     expect(translatedCaptionsStream1).not.toBeNull();
 
     var translationString2 = client.getTranslatedTranscriptText(job.id,"ru");
@@ -174,7 +174,7 @@ test('async translation/summarization submit url', async () => {
     expect(translationObject2).not.toBeNull();
     var translationObject2Stream = client.getTranslatedTranscriptObjectStream(job.id,"ru");
     expect(translationObject2Stream).not.toBeNull();
-    var translatedCaptionsStream2 = client.getTranslatedCaptions(job.id,"ru", undefined, 0);
+    var translatedCaptionsStream2 = client.getTranslatedCaptions(job.id,"ru", undefined);
     expect(translatedCaptionsStream2).not.toBeNull();
 
 }, 180000);

--- a/test/unit/api-client/api-client.async-translation-captions.spec.ts
+++ b/test/unit/api-client/api-client.async-translation-captions.spec.ts
@@ -41,14 +41,5 @@ describe('api-client', () => {
                 { 'Accept': contentType }, 'stream');
             expect(mockMakeApiRequest).toBeCalledTimes(1);
         });
-
-        it('attaches channelId if given', async () => {
-            await sut.getTranslatedCaptions(jobId, translationLanguage, null, 1);
-
-            expect(mockMakeApiRequest).toBeCalledWith('get',
-                `/jobs/${jobId}/captions/translation/${translationLanguage}?speaker_channel=1`,
-                { 'Accept': 'application/x-subrip' }, 'stream');
-            expect(mockMakeApiRequest).toBeCalledTimes(1);
-        });
     });
 });

--- a/test/unit/api-client/api-client.submit.spec.ts
+++ b/test/unit/api-client/api-client.submit.spec.ts
@@ -1,5 +1,4 @@
 import { Readable } from 'stream';
-
 import { RevAiApiClient } from '../../../src/api-client';
 import { ApiRequestHandler } from '../../../src/api-request-handler';
 import { RevAiJobOptions } from '../../../src/models/async/RevAiJobOptions';


### PR DESCRIPTION
REVAI-3917: Split NlpModel to have separate enums for Translation and Summarization
https://revinc.atlassian.net/browse/REVAI-3917