### PR TITLE
REVAI-4573: Update SDKs to support new model

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,5 +5,8 @@ getbaseurl
 # example domains used in unit tests
 www.example.com
 
+# npmjs.com blocks automated link checkers with 403
+https://www.npmjs.com
+
 # email used in unit tests
 test@rev.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "revai-node-sdk",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.8.0",
+      "name": "revai-node-sdk",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revai-node-sdk",
-  "version": "3.8.6",
+  "version": "3.9.0",
   "description": "Rev AI makes speech applications easy to build!",
   "main": "src/index.js",
   "scripts": {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -119,7 +119,10 @@ export class RevAiApiClient {
      */
     async submitJobUrl(mediaUrl: string, options?: RevAiJobOptions): Promise<RevAiApiJob> {
         if (options?.source_config) {
-            throw new Error('source_config.url is not compatible with submitJobUrl. Remove source_config.url from options or use submitJob instead.');
+            throw new Error(
+                'source_config is not compatible with submitJobUrl.'
+                + ' Remove source_config from options or use submitJob instead.'
+            );
         }
 
         options = this.filterNullOptions({

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -118,8 +118,12 @@ export class RevAiApiClient {
      * @deprecated Use submitJob and provide a source config to the job options
      */
     async submitJobUrl(mediaUrl: string, options?: RevAiJobOptions): Promise<RevAiApiJob> {
+        if (options?.source_config) {
+            throw new Error('source_config.url is not compatible with submitJobUrl. Remove source_config.url from options or use submitJob instead.');
+        }
+
         options = this.filterNullOptions({
-            media_url: mediaUrl,
+            source_config: { url: mediaUrl },
             ...(options || {})
         });
 

--- a/test/integration/test/job-v3.test.js
+++ b/test/integration/test/job-v3.test.js
@@ -1,0 +1,14 @@
+const clientHelper = require('../src/client-helper');
+
+test('Can submit url with machine_v3 transcriber', async () => {
+    const client = clientHelper.getAsyncClient();
+    const options = {
+        metadata: 'Node sdk v3 submit url test',
+        transcriber: 'machine_v3'
+    };
+
+    const job = await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3', options);
+
+    expect(job.status).toBe('in_progress');
+    expect(job.id).not.toBeNull();
+}, 30000);

--- a/test/unit/api-client/api-client.submit.spec.ts
+++ b/test/unit/api-client/api-client.submit.spec.ts
@@ -47,7 +47,7 @@ describe('api-client job submission', () => {
             const job = await sut.submitJobUrl(mediaUrl);
 
             expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
-                { 'Content-Type': 'application/json' }, 'json', { media_url: mediaUrl });
+                { 'Content-Type': 'application/json' }, 'json', { source_config: { url: mediaUrl } });
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });
@@ -56,7 +56,7 @@ describe('api-client job submission', () => {
             const job = await sut.submitJobUrl(mediaUrl, null);
 
             expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
-                { 'Content-Type': 'application/json' }, 'json', { media_url: mediaUrl });
+                { 'Content-Type': 'application/json' }, 'json', { source_config: { url: mediaUrl } });
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });
@@ -65,7 +65,7 @@ describe('api-client job submission', () => {
             const job = await sut.submitJobUrl(mediaUrl, {});
 
             expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
-                { 'Content-Type': 'application/json' }, 'json', { media_url: mediaUrl });
+                { 'Content-Type': 'application/json' }, 'json', { source_config: { url: mediaUrl } });
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });
@@ -76,7 +76,7 @@ describe('api-client job submission', () => {
             const job = await sut.submitJobUrl(mediaUrl, options);
 
             expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
-                { 'Content-Type': 'application/json' }, 'json', { media_url: mediaUrl });
+                { 'Content-Type': 'application/json' }, 'json', { source_config: { url: mediaUrl } });
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });
@@ -91,7 +91,6 @@ describe('api-client job submission', () => {
                 speaker_channels_count: 1,
                 speakers_count: 123,
                 filter_profanity: true,
-                media_url: mediaUrl,
                 remove_disfluencies: true,
                 delete_after_seconds: 0,
                 language: 'en',
@@ -102,7 +101,8 @@ describe('api-client job submission', () => {
             const job = await sut.submitJobUrl(mediaUrl, options);
 
             expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
-                { 'Content-Type': 'application/json' }, 'json', options);
+                { 'Content-Type': 'application/json' }, 'json',
+                { ...options, source_config: { url: mediaUrl } });
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });
@@ -115,7 +115,7 @@ describe('api-client job submission', () => {
             const job = await sut.submitJobUrl(mediaUrl, options);
 
             expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
-                { 'Content-Type': 'application/json' }, 'json', { ...options, media_url: mediaUrl });
+                { 'Content-Type': 'application/json' }, 'json', { ...options, source_config: { url: mediaUrl } });
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });
@@ -144,7 +144,7 @@ describe('api-client job submission', () => {
             const job = await sut.submitJobUrl(mediaUrl, options);
 
             expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
-                { 'Content-Type': 'application/json' }, 'json', { ...options, media_url: mediaUrl });
+                { 'Content-Type': 'application/json' }, 'json', { ...options, source_config: { url: mediaUrl } });
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });

--- a/test/unit/api-client/api-client.submit.spec.ts
+++ b/test/unit/api-client/api-client.submit.spec.ts
@@ -160,12 +160,14 @@ describe('api-client job submission', () => {
 
         it('submit job with media url throws error when options contain source_config', async () => {
             const options: RevAiJobOptions = {
-                source_config: { url: 'https://other.url/audio.mp3' }
+                source_config: { url: mediaUrl }
             };
 
-            await expect(sut.submitJobUrl(mediaUrl, options)).rejects.toThrow(
-                'source_config.url is not compatible with submitJobUrl. Remove source_config.url from options or use submitJob instead.'
-            );
+            await expect(sut.submitJobUrl(mediaUrl, options))
+                .rejects.toThrow(
+                    'source_config is not compatible with submitJobUrl.'
+                    + ' Remove source_config from options'
+                );
             expect(mockMakeApiRequest).not.toBeCalled();
         });
     });

--- a/test/unit/api-client/api-client.submit.spec.ts
+++ b/test/unit/api-client/api-client.submit.spec.ts
@@ -148,6 +148,26 @@ describe('api-client job submission', () => {
             expect(mockMakeApiRequest).toBeCalledTimes(1);
             expect(job).toEqual(jobDetails);
         });
+
+        it('submit job with media url sends source_config instead of media_url', async () => {
+            const job = await sut.submitJobUrl(mediaUrl);
+
+            expect(mockMakeApiRequest).toBeCalledWith('post', '/jobs',
+                { 'Content-Type': 'application/json' }, 'json', { source_config: { url: mediaUrl } });
+            expect(mockMakeApiRequest).toBeCalledTimes(1);
+            expect(job).toEqual(jobDetails);
+        });
+
+        it('submit job with media url throws error when options contain source_config', async () => {
+            const options: RevAiJobOptions = {
+                source_config: { url: 'https://other.url/audio.mp3' }
+            };
+
+            await expect(sut.submitJobUrl(mediaUrl, options)).rejects.toThrow(
+                'source_config.url is not compatible with submitJobUrl. Remove source_config.url from options or use submitJob instead.'
+            );
+            expect(mockMakeApiRequest).not.toBeCalled();
+        });
     });
 
     describe('submitJob', () => {


### PR DESCRIPTION
## Description of Work

Migrates `submitJobUrl` from sending `media_url` to `source_config`, enabling support for the `machine_v3` transcriber.

### What Changed

- **`src/api-client.ts`**: `submitJobUrl` now builds `source_config: { url: mediaUrl }` instead of `media_url: mediaUrl`. Added validation that throws if the caller also passes `source_config` in options (conflicting with the `mediaUrl` parameter).
- **`test/unit/api-client/api-client.submit.spec.ts`**: Updated all existing `submitJobUrl` assertions from `media_url` to `source_config`. Added 2 new tests: one verifying the `source_config` payload shape, one verifying the conflict error.
- **`test/integration/test/job-v3.test.js`**: New integration test that submits a job via `submitJobUrl` with `transcriber: 'machine_v3'` and verifies success.

## Screenshots

### Test script (`examples/submit_job_url_v3.js`)

```javascript
require('dotenv').config();

const revai = require('../dist/src');

const token = process.env.API_KEY;
const baseUrl = process.env.BASE_URL;

(async () => {
    var client = new revai.RevAiApiClient({ token });

    if (baseUrl) {
        client.apiHandler.instance.defaults.baseURL = `${baseUrl}/speechtotext/v1/`;
    }

    // Submit a job using submitJobUrl with machine_v3 transcriber
    console.log('Submitting job with submitJobUrl and machine_v3 transcriber...');
    var job = await client.submitJobUrl('https://www.rev.ai/FTC_Sample_1.mp3', {
        transcriber: 'machine_v3',
        metadata: 'Node SDK submitJobUrl v3 test'
    });

    console.log(`Job Id: ${job.id}`);
    console.log(`Status: ${job.status}`);
    console.log(`Created On: ${job.created_on}`);

    // Poll until complete
    var jobStatus;
    while ((jobStatus = (await client.getJobDetails(job.id)).status) === revai.JobStatus.InProgress) {
        console.log(`Job ${job.id} is ${jobStatus}, waiting...`);
        await new Promise(resolve => setTimeout(resolve, 5000));
    }

    console.log(`Job ${job.id} final status: ${jobStatus}`);

    if (jobStatus === revai.JobStatus.Transcribed) {
        var transcript = await client.getTranscriptText(job.id);
        console.log('\n--- Transcript (first 500 chars) ---');
        console.log(transcript.substring(0, 500));
    } else {
        console.log('Job did not complete successfully.');
        var details = await client.getJobDetails(job.id);
        console.log('Job details:', JSON.stringify(details, null, 2));
    }
})();
```

### Output (local API)

```
Submitting job with submitJobUrl and machine_v3 transcriber...
Job Id: T8c2aaJXoJHP
Status: in_progress
Created On: 2026-02-18T16:53:52.855Z
Job T8c2aaJXoJHP is in_progress, waiting...
```

Job was accepted by the API (no 400 error) and is processing. Previously this would fail with `media_url is not supported for machine_v3 transcriber. Use source_config instead.`

## Questions

- [x] `submitJobUrl` is marked `@deprecated` (predating this PR) with the message "Use submitJob and provide a source config to the job options." Now that `submitJobUrl` internally uses `source_config`, it works correctly with all transcribers including `machine_v3`. Should we remove `submitJobUrl` entirely in a future release, or remove the deprecation notice since it now behaves correctly? If we keep the deprecation, what is the concrete condition/timeline for actually removing it?

## Additional Comments

If you have any additional comments or notes for reviewers, please add them here.